### PR TITLE
Fix UI endpoints

### DIFF
--- a/src/lib/api/discovery.ts
+++ b/src/lib/api/discovery.ts
@@ -1,33 +1,12 @@
-import { throwError } from './errors';
+
 import { clouditorize } from './util';
 
-export interface GraphEdge {
-	id: string;
-	source: string;
-	target: string;
-}
 
 export interface StartDiscoveryResponse {
 	successful: boolean;
 }
 
-export interface QueryResponse {
-	results: Resource[];
-}
 
-export interface ListGraphEdgesResponse {
-	edges: GraphEdge[];
-}
-
-export interface ListResourcesRequest {
-	filter?: Filter;
-	orderBy?: string;
-}
-
-export interface Filter {
-	cloudServiceId?: string;
-	type?: string;
-}
 
 export interface HttpEndpoint {
 	transportEncryption?: TransportEncryption;
@@ -40,21 +19,6 @@ export interface TransportEncryption {
 	tlsVersion: string;
 }
 
-export interface ResourceProperties {
-	name: string;
-	raw: string;
-	type: string[];
-	serviceId: string;
-	id: string;
-	labels: object;
-}
-
-export interface Resource {
-	id: string;
-	cloudServiceId: string;
-	resourceType: string;
-	properties: ResourceProperties;
-}
 
 export async function startDiscovery(): Promise<boolean> {
 	const apiUrl = clouditorize(`/v1/discovery/start`);
@@ -71,44 +35,4 @@ export async function startDiscovery(): Promise<boolean> {
 		});
 }
 
-export async function listResources(
-	filteredServiceId?: string,
-	type = '',
-	fetch = window.fetch
-): Promise<Resource[]> {
-	let apiUrl =
-		clouditorize(`/v1/discovery/resources?filter.cloudServiceId=${filteredServiceId}&pageSize=1500&orderBy=resource_type&asc=true
-    `);
 
-	if (type != '') {
-		apiUrl += `&filter.type=${type}`;
-	}
-
-	return fetch(apiUrl, {
-		method: 'GET',
-		headers: {
-			Authorization: `Bearer ${localStorage.token}`
-		}
-	})
-		.then(throwError)
-		.then((res) => res.json())
-		.then((response: QueryResponse) => {
-			return response.results;
-		});
-}
-
-export async function listGraphEdges(fetch = window.fetch): Promise<GraphEdge[]> {
-	const apiUrl = clouditorize(`/v1experimental/discovery/graph/edges?&pageSize=1500`);
-
-	return fetch(apiUrl, {
-		method: 'GET',
-		headers: {
-			Authorization: `Bearer ${localStorage.token}`
-		}
-	})
-		.then(throwError)
-		.then((res) => res.json())
-		.then((response: ListGraphEdgesResponse) => {
-			return response.edges;
-		});
-}

--- a/src/lib/api/evaluation.ts
+++ b/src/lib/api/evaluation.ts
@@ -20,7 +20,7 @@ export type ComplianceStatus =
 
 export interface EvaluationResult {
 	id: string;
-	cloudServiceId: string;
+	targetOfEvaluationId: string;
 	status: ComplianceStatus;
 	controlCatalogId: string;
 	controlCategoryName?: string;
@@ -45,7 +45,7 @@ export async function startEvaluation(auditScope: AuditScope): Promise<StartEval
 
 export async function stopEvaluation(auditScope: AuditScope): Promise<{}> {
 	const apiUrl = clouditorize(
-		`/v1/evaluation/evaluate/${auditScope.certificationTargetId}/${auditScope.catalogId}/stop`
+		`/v1/evaluation/evaluate/${auditScope.id}/stop`
 	);
 
 	return fetch(apiUrl, {
@@ -57,10 +57,12 @@ export async function stopEvaluation(auditScope: AuditScope): Promise<{}> {
 }
 
 export interface ListEvaluationResultsFilter {
-	cloudServiceId?: string;
+	targetOfEvaluationId?: string;
 	catalogId?: string;
 	controlId?: string;
+	subControls?: string;
 	parentsOnly?: boolean;
+	validManualOnly?: boolean;
 }
 
 export async function listEvaluationResults(
@@ -70,8 +72,8 @@ export async function listEvaluationResults(
 ): Promise<EvaluationResult[]> {
 	let apiUrl = clouditorize(`/v1/evaluation/results?`);
 
-	if (filter?.cloudServiceId != undefined) {
-		apiUrl += `&filter.certification_target_id=${filter?.cloudServiceId}`;
+	if (filter?.targetOfEvaluationId != undefined) {
+		apiUrl += `&filter.target_of_evaluation_id=${filter?.targetOfEvaluationId}`;
 	}
 	if (filter?.catalogId != undefined) {
 		apiUrl += `&filter.catalog_id=${filter?.catalogId}`;

--- a/src/lib/api/evidence_store.ts
+++ b/src/lib/api/evidence_store.ts
@@ -1,0 +1,93 @@
+import { throwError } from './errors';
+import { clouditorize } from './util';
+
+
+export interface GraphEdge {
+	id: string;
+	source: string;
+	target: string;
+    type: string;
+}
+
+export interface ListGraphEdgesRequest {
+	
+	orderBy?: string;
+	pageSize?: number;
+	asc?: boolean;
+}
+export interface ListGraphEdgesResponse {
+	edges: GraphEdge[];
+}
+
+export interface ListResourcesRequest {
+	filter?: Filter;
+	orderBy?: string;
+}
+
+export interface ListResourcesResponse {
+	results: Resource[];
+}
+
+
+export interface Filter {
+	targetOfEvaluationId?: string;
+	type?: string;
+}
+
+export interface ResourceProperties {
+    name: string;
+    raw: string;
+    type: string[];
+    serviceId: string;
+    id: string;
+    labels: object;
+}
+
+export interface Resource {
+    id: string;
+    targetOfEvaluationId: string;
+    resourceType: string;
+    properties: ResourceProperties;
+}
+
+export async function listResources(
+	filteredTargetOfEvaluationId?: string,
+	type = '',
+	fetch = window.fetch
+): Promise<Resource[]> {
+	let apiUrl =
+		clouditorize(`/v1/evidence_store/resources?filter.targetOfEvaluationId=${filteredTargetOfEvaluationId}&pageSize=1500&orderBy=resource_type&asc=true
+    `);
+
+	if (type != '') {
+		apiUrl += `&filter.type=${type}`;
+	}
+
+	return fetch(apiUrl, {
+		method: 'GET',
+		headers: {
+			Authorization: `Bearer ${localStorage.token}`
+		}
+	})
+		.then(throwError)
+		.then((res) => res.json())
+		.then((response: ListResourcesResponse) => {
+			return response.results;
+		});
+}
+
+export async function listGraphEdges(fetch = window.fetch): Promise<GraphEdge[]> {
+	const apiUrl = clouditorize(`/v1experimental/evidence/graph/edges`);//?pageSize=1500`);
+
+	return fetch(apiUrl, {
+		method: 'GET',
+		headers: {
+			Authorization: `Bearer ${localStorage.token}`
+		}
+	})
+		.then(throwError)
+		.then((res) => res.json())
+		.then((response: ListGraphEdgesResponse) => {
+			return response.edges;
+		});
+}

--- a/src/lib/api/orchestrator.ts
+++ b/src/lib/api/orchestrator.ts
@@ -22,12 +22,13 @@ export interface Tag {
 	tag: object;
 }
 
-export interface CertificationTarget {
+export interface TargetOfEvaluation {
 	id: string;
 	name: string;
 	description?: string;
 	metadata: {
 		labels?: Tag[] | string;
+		icon?: string;
 	};
 	createdAt: string;
 	updatedAt: string;
@@ -35,14 +36,14 @@ export interface CertificationTarget {
 
 export interface AuditScope {
 	id: string;
-	certificationTargetId: string;
+	name: string;
+	targetOfEvaluationId: string;
 	catalogId: string;
 	assuranceLevel?: string;
-	controlsInScope?: Control[];
 }
 
 export interface ControlInScope {
-	auditScopeCertificationTargetId: string;
+	auditScopeTargetOfEvaluationId: string;
 	auditScopeCatalogId: string;
 	controlId: string;
 	controlCategoryName: string;
@@ -105,7 +106,7 @@ export interface ListMetricConfigurationsResponse {
 export interface Certificate {
 	id: string;
 	name: string;
-	certificationTargetId: string;
+	targetOfEvaluationId: string;
 	issueDate: string;
 	expirationDate: string;
 	standard: string;
@@ -139,8 +140,8 @@ export interface ListAssessmentResultsResponse {
 	results: AssessmentResult[];
 }
 
-export interface ListCertificationTargetsResponse {
-	targets: CertificationTarget[];
+export interface ListTargetsOfEvaluationResponse {
+	targets: TargetOfEvaluation[];
 }
 
 export interface ListAuditScopesResponse {
@@ -182,7 +183,7 @@ export async function listAssessmentResults(
 	latestByResourceId = false
 ): Promise<AssessmentResult[]> {
 	const apiUrl = clouditorize(
-		`/v1/orchestrator/assessment_results?pageSize=1500&latestByResourceId=${latestByResourceId}&orderBy=timestamp&asc=false`
+		`/v1/orchestrator/assessment_results?pageSize=1500&latestByResourceId=${latestByResourceId}&asc=false`
 	);
 
 	return fetch(apiUrl, {
@@ -203,12 +204,12 @@ export async function listAssessmentResults(
  *
  * @returns an array of {@link AssessmentResult}s.
  */
-export async function listCertificationTargetAssessmentResults(
+export async function listTargetOfEvaluationAssessmentResults(
 	serviceId: string,
 	fetch = window.fetch
 ): Promise<AssessmentResult[]> {
 	const apiUrl = clouditorize(
-		`/v1/orchestrator/assessment_results?pageSize=1000&filter.certificationTargetId=${serviceId}&orderBy=timestamp&asc=false`
+		`/v1/orchestrator/assessment_results?pageSize=1000&filter.targetOfEvaluationId=${serviceId}&asc=false`
 	);
 
 	return fetch(apiUrl, {
@@ -271,7 +272,7 @@ export async function getMetricImplementation(id: string): Promise<MetricImpleme
 /**
  * Retrieves a particular metric configuration from the orchestrator service.
  *
- * @param serviceId the Certification Target ID
+ * @param serviceId the Target of Evaluation ID
  * @param metricId the metric id
  * @returns metric configuration
  */
@@ -280,7 +281,7 @@ export async function getMetricConfiguration(
 	metricId: string
 ): Promise<MetricConfiguration> {
 	const apiUrl = clouditorize(
-		`/v1/orchestrator/certification_targets/${serviceId}/metric_configurations/${metricId}`
+		`/v1/orchestrator/targets_of_evaluation/${serviceId}/metric_configurations/${metricId}`
 	);
 
 	return fetch(apiUrl, {
@@ -307,7 +308,7 @@ export async function listMetricConfigurations(
 	skipDefault = false
 ): Promise<Map<string, MetricConfiguration>> {
 	const apiUrl = clouditorize(
-		`/v1/orchestrator/certification_targets/${serviceId}/metric_configurations`
+		`/v1/orchestrator/targets_of_evaluation/${serviceId}/metric_configurations`
 	);
 
 	return fetch(apiUrl, {
@@ -332,12 +333,12 @@ export async function listMetricConfigurations(
 }
 
 /**
- * Creates a new certification target
+ * Creates a new Target of Evaluation
  */
-export async function registerCertificationTarget(
-	service: CertificationTarget
-): Promise<CertificationTarget> {
-	const apiUrl = clouditorize(`/v1/orchestrator/certification_targets`);
+export async function registerTargetOfEvaluation(
+	service: TargetOfEvaluation
+): Promise<TargetOfEvaluation> {
+	const apiUrl = clouditorize(`/v1/orchestrator/targets_of_evaluation`);
 
 	return fetch(apiUrl, {
 		method: 'POST',
@@ -348,16 +349,16 @@ export async function registerCertificationTarget(
 	})
 		.then(throwError)
 		.then((res) => res.json())
-		.then((response: CertificationTarget) => {
+		.then((response: TargetOfEvaluation) => {
 			return response;
 		});
 }
 
 /**
- * Removes a certification target.
+ * Removes a Target of Evaluation.
  */
-export async function removeCertificationTarget(targetId: string): Promise<void> {
-	const apiUrl = clouditorize(`/v1/orchestrator/certification_targets/${targetId}`);
+export async function removeTargetOfEvaluation(targetId: string): Promise<void> {
+	const apiUrl = clouditorize(`/v1/orchestrator/targets_of_evaluation/${targetId}`);
 
 	return fetch(apiUrl, {
 		method: 'DELETE',
@@ -370,14 +371,14 @@ export async function removeCertificationTarget(targetId: string): Promise<void>
 }
 
 /**
- * Retrieves a list of certification targets from the orchestrator service.
+ * Retrieves a list of Targets of Evaluation from the orchestrator service.
  *
- * @returns an array of {@link CertificationTarget}s.
+ * @returns an array of {@link TargetOfEvaluation}s.
  */
-export async function listCertificationTargets(
+export async function listTargetsOfEvaluation(
 	fetch = window.fetch
-): Promise<CertificationTarget[]> {
-	const apiUrl = clouditorize(`/v1/orchestrator/certification_targets`);
+): Promise<TargetOfEvaluation[]> {
+	const apiUrl = clouditorize(`/v1/orchestrator/targets_of_evaluation`);
 
 	return fetch(apiUrl, {
 		method: 'GET',
@@ -387,13 +388,13 @@ export async function listCertificationTargets(
 	})
 		.then(throwError)
 		.then((res) => res.json())
-		.then((response: ListCertificationTargetsResponse) => {
+		.then((response: ListTargetsOfEvaluationResponse) => {
 			return response.targets;
 		});
 }
 
 /**
- * Creates a new target of evaluation.
+ * Creates a new Audit Scope.
  */
 export async function createAuditScope(target: AuditScope): Promise<AuditScope> {
 	const apiUrl = clouditorize(`/v1/orchestrator/audit_scopes`);
@@ -410,7 +411,7 @@ export async function createAuditScope(target: AuditScope): Promise<AuditScope> 
 }
 
 /**
- * Removes a target of evaluation.
+ * Removes an Audit Scope.
  */
 export async function removeAuditScope(target: AuditScope): Promise<AuditScope> {
 	const apiUrl = clouditorize(`/v1/orchestrator/audit_scopes/${target.id}`);
@@ -427,7 +428,7 @@ export async function removeAuditScope(target: AuditScope): Promise<AuditScope> 
 }
 
 /**
- * Retrieves a list of targets of evaluation from the orchestrator service.
+ * Retrieves a list of Audit Scopes from the orchestrator service.
  *
  * @returns an array of {@link AuditScope}s.
  */
@@ -436,7 +437,7 @@ export async function listAuditScopes(
 	fetch = window.fetch
 ): Promise<AuditScope[]> {
 	const apiUrl = clouditorize(
-		`/v1/orchestrator/audit_scopes?filter.certificationTargetId=${serviceId}`
+		`/v1/orchestrator/audit_scopes?filter.targetOfEvaluationId=${serviceId}`
 	);
 
 	return fetch(apiUrl, {
@@ -535,15 +536,15 @@ export async function listControls(
 }
 
 /**
- * Retrieve a certification target from the orchestrator service using its ID.
+ * Retrieve a Target of Evaluation from the orchestrator service using its ID.
  *
- * @returns the certification target
+ * @returns the Target of Evaluation
  */
-export async function getCertificationTarget(
+export async function getTargetOfEvaluation(
 	id: string,
 	fetch = window.fetch
-): Promise<CertificationTarget> {
-	const apiUrl = clouditorize(`/v1/orchestrator/certification_targets/${id}`);
+): Promise<TargetOfEvaluation> {
+	const apiUrl = clouditorize(`/v1/orchestrator/targets_of_evaluation/${id}`);
 
 	return fetch(apiUrl, {
 		method: 'GET',
@@ -555,11 +556,11 @@ export async function getCertificationTarget(
 		.then((res) => res.json());
 }
 
-export async function updateCertificationTarget(
-	service: CertificationTarget,
+export async function updateTargetOfEvaluation(
+	service: TargetOfEvaluation,
 	fetch = window.fetch
-): Promise<CertificationTarget> {
-	const apiUrl = clouditorize(`/v1/orchestrator/certification_targets/${service.id}`);
+): Promise<TargetOfEvaluation> {
+	const apiUrl = clouditorize(`/v1/orchestrator/targets_of_evaluation/${service.id}`);
 
 	return fetch(apiUrl, {
 		method: 'PUT',
@@ -570,7 +571,7 @@ export async function updateCertificationTarget(
 	})
 		.then(throwError)
 		.then((res) => res.json())
-		.then((response: CertificationTarget) => {
+		.then((response: TargetOfEvaluation) => {
 			return response;
 		});
 }
@@ -578,9 +579,9 @@ export async function updateCertificationTarget(
 export async function updateControlInScope(
 	scope: ControlInScope,
 	fetch = window.fetch
-): Promise<CertificationTarget> {
+): Promise<TargetOfEvaluation> {
 	const apiUrl = clouditorize(
-		`/v1/orchestrator/certification_targets/${scope.auditScopeCertificationTargetId}/audit_scopes/${scope.auditScopeCatalogId}/controls_in_scope/categories/${scope.controlCategoryName}/controls/${scope.controlId}`
+		`/v1/orchestrator/targets_of_evaluation/${scope.auditScopeTargetOfEvaluationId}/audit_scopes/${scope.auditScopeCatalogId}/controls_in_scope/categories/${scope.controlCategoryName}/controls/${scope.controlId}`
 	);
 
 	return fetch(apiUrl, {
@@ -592,7 +593,7 @@ export async function updateControlInScope(
 	})
 		.then(throwError)
 		.then((res) => res.json())
-		.then((response: CertificationTarget) => {
+		.then((response: TargetOfEvaluation) => {
 			return response;
 		});
 }

--- a/src/lib/components/CatalogComplianceItem.svelte
+++ b/src/lib/components/CatalogComplianceItem.svelte
@@ -30,7 +30,7 @@
 
 <li class="overflow-hidden rounded-xl border border-gray-200">
 	<div class="flex items-center justify-between gap-x-4 border-b border-gray-900/5 bg-gray-50 p-6">
-		<a href={'/cloud/' + auditScope.certificationTargetId + '/compliance/' + catalog.id}>
+		<a href={'/cloud/' + auditScope.targetOfEvaluationId + '/compliance/' + catalog.id}>
 			<div class="text-sm font-medium leading-6 text-gray-900">{catalog.name}</div>
 			<div class="text-sm text-gray-500">{catalog.description}</div>
 		</a>

--- a/src/lib/components/ComplianceChart.svelte
+++ b/src/lib/components/ComplianceChart.svelte
@@ -67,7 +67,7 @@
 				}
 
 				goto(
-					`/cloud/${auditScope.certificationTargetId}/compliance/${auditScope.catalogId}?${params.toString()}`
+					`/cloud/${auditScope.targetOfEvaluationId}/compliance/${auditScope.catalogId}?${params.toString()}`
 				);
 			}
 		};

--- a/src/lib/components/GraphEdge.svelte
+++ b/src/lib/components/GraphEdge.svelte
@@ -3,7 +3,7 @@
 
 	let { edge } = $props();
 
-	const { getCyInstance } = getContext('graphSharedState');
+	const { getCyInstance } = getContext<{ getCyInstance: () => any }>('graphSharedState');
 	const cy = getCyInstance();
 
 	try {

--- a/src/lib/components/GraphNode.svelte
+++ b/src/lib/components/GraphNode.svelte
@@ -3,7 +3,7 @@
 
 	let { node } = $props();
 
-	const { getCyInstance } = getContext('graphSharedState');
+	const { getCyInstance } = getContext<{ getCyInstance: () => any }>('graphSharedState');
 	const cy = getCyInstance();
 
 	cy.add({

--- a/src/lib/components/NodeDetail.svelte
+++ b/src/lib/components/NodeDetail.svelte
@@ -2,7 +2,7 @@
 	import { run } from 'svelte/legacy';
 
 	import type { AssessmentResult, Metric } from '$lib/api/assessment';
-	import type { Resource, listResources } from '$lib/api/discovery';
+	import type { Resource } from '$lib/api/evidence_store';
 	import AssessmentIcon from './AssessmentIcon.svelte';
 	import { flatten } from 'flat';
 
@@ -127,7 +127,7 @@
 									<div class="pl-7 text-sm leading-6">
 										<label for="privacy-public" class="font-medium text-gray-900">
 											<a
-												href={`/cloud/${selected.cloudServiceId}/assessments/?filterIds=${result.id}`}
+												href={`/cloud/${selected.targetOfEvaluationId}/assessments/?filterIds=${result.id}`}
 											>
 												{metrics.get(result.metricId)?.name}
 											</a>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { CertificationTarget } from '$lib/api/orchestrator';
+	import type { TargetOfEvaluation } from '$lib/api/orchestrator';
 	import NavigationItem from '$lib/components/NavigationItem.svelte';
 	import {
 		AdjustmentsHorizontal,
@@ -12,7 +12,7 @@
 	import { Icon } from '@steeze-ui/svelte-icon';
 
 	interface Props {
-		services: CertificationTarget[];
+		services: TargetOfEvaluation[];
 		mobile?: boolean;
 	}
 
@@ -22,7 +22,7 @@
 	let navigation = $derived([
 		{ name: 'Dashboard', href: '/dashboard', icon: Home, disabled: true },
 		{
-			name: 'Certification Targets',
+			name: 'Targets of Evaluation',
 			href: '/cloud',
 			icon: Folder,
 			children: [

--- a/src/lib/components/Wizard.svelte
+++ b/src/lib/components/Wizard.svelte
@@ -2,7 +2,7 @@
 	// WizardData contains all the data that the wizard creates, such as the cloud
 	// service, its meta-data and optionally some target of evaluations.
 	export interface WizardData {
-		service: CertificationTarget;
+		service: TargetOfEvaluation;
 		catalogs: Catalog[];
 		auditScopes: AuditScope[];
 		mode: 'create' | 'edit';
@@ -16,7 +16,7 @@
 	import WizardStepInfo from './WizardStepInfo.svelte';
 	import WizardStepSave from './WizardStepSave.svelte';
 	import WizardStepCatalog from './WizardStepCatalog.svelte';
-	import type { Catalog, CertificationTarget, AuditScope } from '$lib/api/orchestrator';
+	import type { Catalog, TargetOfEvaluation, AuditScope } from '$lib/api/orchestrator';
 	import type { SvelteComponent } from 'svelte';
 
 	interface Props {
@@ -38,14 +38,14 @@
 		content: typeof SvelteComponent;
 	}[] = [
 		{
-			name: 'Create certification target',
-			description: 'Please provide a name for the certification target.',
+			name: 'Create Target of Evaluation',
+			description: 'Please provide a name for the Target of Evaluation.',
 			href: '?step=0',
 			content: WizardStepName
 		},
 		{
 			name: 'Service information',
-			description: 'Optionally specify additional information about the certification target.',
+			description: 'Optionally specify additional information about the Target of Evaluation.',
 			href: '?step=1',
 			content: WizardStepInfo
 		},
@@ -57,7 +57,7 @@
 		},
 		{
 			name: 'Confirm',
-			description: 'Confirm creation of certification target.',
+			description: 'Confirm creation of Target of Evaluation.',
 			href: '?step=3',
 			content: WizardStepSave
 		}
@@ -65,7 +65,7 @@
 </script>
 
 <nav aria-label="Progress" class="mt-4">
-	<ol class="overflow-hidden">
+	<ol class="overflow-hidden overflow-y-visible">
 		{#each steps as step, stepIdx}
 			<li class="{stepIdx !== steps.length - 1 ? 'pb-10' : ''} relative">
 				{#if stepIdx < current}

--- a/src/lib/components/WizardStepCatalog.svelte
+++ b/src/lib/components/WizardStepCatalog.svelte
@@ -43,7 +43,7 @@
 				catalogId: catalog.id,
 				// This will not be the final ID, since we do not know it at this point.
 				// This needs to be set by the caller of save()
-				certificationTargetId: data.service.id,
+				targetOfEvaluationId: data.service.id,
 				assuranceLevel: assuranceLevel
 			};
 

--- a/src/lib/components/WizardStepSave.svelte
+++ b/src/lib/components/WizardStepSave.svelte
@@ -22,15 +22,15 @@
 
 <div class="mb-5 text-sm">
 	{#if data.service.name.length == 0}
-		Please provide at least a name for the new certification target.
+		Please provide at least a name for the new Target of Evaluation.
 	{:else}
 		{#if data.mode == 'create'}
-			This will create a new certification target called <b>{data.service.name}</b> with
+			This will create a new Target of Evaluation called <b>{data.service.name}</b> with
 		{:else}
-			This will change the certification target called <b>{data.service.name}</b> with
+			This will change the Target of Evaluation called <b>{data.service.name}</b> with
 		{/if}
 		{#if data.auditScopes.length > 0}
-			the following targets of evaluation:
+			the following Targets of Evaluation:
 			<ul class="ml-4 mt-1 list-disc">
 				{#each data.auditScopes as auditScope}
 					<li>
@@ -42,7 +42,7 @@
 				{/each}
 			</ul>
 		{:else}
-			no configured target of evaluation.
+			no configured Target of Evaluation.
 		{/if}
 	{/if}
 </div>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,1 @@
+// place files you want to import through the `$lib` alias in this folder.

--- a/src/routes/(app)/+layout.ts
+++ b/src/routes/(app)/+layout.ts
@@ -1,9 +1,9 @@
-import { listCatalogs, listCertificationTargets, listMetrics } from '$lib/api/orchestrator';
+import { listCatalogs, listTargetsOfEvaluation, listMetrics } from '$lib/api/orchestrator';
 import type { LayoutLoad } from './$types';
 
 export const load = (async ({ fetch }) => {
 	const [services, catalogs, metricList] = await Promise.all([
-		listCertificationTargets(fetch),
+		listTargetsOfEvaluation(fetch),
 		listCatalogs(fetch),
 		listMetrics(fetch)
 	]);

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Welcome to SvelteKit</h1>
+<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>

--- a/src/routes/(app)/cloud/+page.svelte
+++ b/src/routes/(app)/cloud/+page.svelte
@@ -10,20 +10,20 @@
 
 	let { data }: Props = $props();
 
-	// Make sure, that our list of certification targets is up-to-date
-	invalidate((url) => url.pathname == '/v1/orchestrator/certification_targets');
+	// Make sure, that our list of Targets of Evaluation is up-to-date
+	invalidate((url) => url.pathname == '/v1/orchestrator/targets_of_evaluation');
 </script>
 
 <Header
-	name="Certification Targets"
-	description="{data.services.length} certification target(s) configured"
+	name="Targets of Evaluation"
+	description="{data.services.length} target(s) of Evaluation configured"
 	buttons={false}
 	icon={false}
 />
 
 <BelowHeader>
-	This page provides an overview of all configured certification targets within Clouditor. Click on
-	the name of a certification target to display more information about it.
+	This page provides an overview of all configured Targets of Evaluation within Clouditor. Click on
+	the name of a Target of Evaluation to display more information about it.
 </BelowHeader>
 
 <ul class="divide-y divide-gray-100">

--- a/src/routes/(app)/cloud/[id]/+layout.svelte
+++ b/src/routes/(app)/cloud/[id]/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { removeCertificationTarget } from '$lib/api/orchestrator';
+	import { removeTargetOfEvaluation } from '$lib/api/orchestrator';
 	import Header from '$lib/components/Header.svelte';
 	import Tabs from '$lib/components/Tabs.svelte';
 	import { CheckBadge, Cog6Tooth, QueueList, Squares2x2, Sun, User } from '@steeze-ui/heroicons';
@@ -49,13 +49,13 @@
 	]);
 
 	async function remove(e: CustomEvent) {
-		let really = confirm('Do you really want to delete this certification target?');
+		let really = confirm('Do you really want to delete this Target of Evaluation?');
 
 		if (!really) {
 			return;
 		}
 
-		await removeCertificationTarget(data.service.id);
+		await removeTargetOfEvaluation(data.service.id);
 		goto('/cloud');
 	}
 </script>

--- a/src/routes/(app)/cloud/[id]/+layout.ts
+++ b/src/routes/(app)/cloud/[id]/+layout.ts
@@ -1,14 +1,14 @@
-import { getCertificationTarget } from '$lib/api/orchestrator';
+import { getTargetOfEvaluation } from '$lib/api/orchestrator';
 import { error } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
-import { listResources } from '$lib/api/discovery';
+import { listResources } from '$lib/api/evidence_store';
 
 export const load = (async ({ fetch, params }) => {
 	if (params.id == undefined) {
 		error(405, 'Required parameter missing');
 	}
 
-	const service = await getCertificationTarget(params.id, fetch);
+	const service = await getTargetOfEvaluation(params.id, fetch);
 
 	// TODO: replace with statistics endpoint to avoid slow loading of resource data
 	const resources = await listResources(service.id, '', fetch);

--- a/src/routes/(app)/cloud/[id]/+page.ts
+++ b/src/routes/(app)/cloud/[id]/+page.ts
@@ -6,7 +6,7 @@ export const load = (async ({ params }) => {
 		error(405, 'Required parameter missing');
 	}
 
-	// In case someone access the "root" of a certification target, we redirect him to
+	// In case someone access the "root" of a Target of Evaluation, we redirect him to
 	// the activity view
 	redirect(301, '/cloud/' + params.id + '/activity');
 }) satisfies PageLoad;

--- a/src/routes/(app)/cloud/[id]/activity/+page.svelte
+++ b/src/routes/(app)/cloud/[id]/activity/+page.svelte
@@ -48,7 +48,7 @@
 		const date = new Date(data.service.createdAt);
 
 		timeline.push({
-			content: 'Created certification target',
+			content: 'Created Target of Evaluation',
 			target: data.service.name,
 			href: '/cloud/' + data.service.id,
 			date: formatDate(date),

--- a/src/routes/(app)/cloud/[id]/activity/+page.ts
+++ b/src/routes/(app)/cloud/[id]/activity/+page.ts
@@ -1,4 +1,4 @@
-import { listCertificationTargetAssessmentResults } from '$lib/api/orchestrator';
+import { listTargetOfEvaluationAssessmentResults } from '$lib/api/orchestrator';
 import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
@@ -7,7 +7,7 @@ export const load = (async ({ fetch, params }) => {
 		error(405, 'Required parameter missing');
 	}
 
-	const results = await listCertificationTargetAssessmentResults(params.id, fetch);
+	const results = await listTargetOfEvaluationAssessmentResults(params.id, fetch);
 
 	return {
 		results: results

--- a/src/routes/(app)/cloud/[id]/assessments/+page.svelte
+++ b/src/routes/(app)/cloud/[id]/assessments/+page.svelte
@@ -70,6 +70,7 @@ https://svelte.dev/e/node_invalid_placement -->
 	function closeModal() {
 		showModalId = null;
 	}
+  
 </script>
 
 {#if data.resources.length == 0}
@@ -84,15 +85,7 @@ https://svelte.dev/e/node_invalid_placement -->
 				<table class="min-w-full table-fixed divide-y divide-gray-200">
 					<thead class="bg-gray-50">
 						<tr>
-							{#if showModalId != null}
-								<th
-									scope="col"
-									class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500"
-								>
-									Details
-								</th>
-							{:else}
-								<th
+							<th
 									scope="col"
 									class="w-1/12 px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500"
 								>
@@ -127,7 +120,6 @@ https://svelte.dev/e/node_invalid_placement -->
 									class="w-1/12 px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500"
 								>
 								</th>
-							{/if}
 						</tr>
 					</thead>
 					<tbody class="divide-y divide-gray-200 bg-white">
@@ -150,11 +142,16 @@ https://svelte.dev/e/node_invalid_placement -->
 								</td>
 								<td class="max-w-xs truncate whitespace-nowrap px-6 py-4">
 									<span class="text-sm text-gray-900">
-										<a href={`/cloud/${data.service.id}/graph/?id=${assessment.resourceId}`}>
+										<a href={`/cloud/${data.service.id}/resource/?id=${assessment.resourceId}`}>
 											{assessment.resourceId.split('/')[
 												assessment.resourceId.split('/').length - 1
 											]}
 										</a>
+										<!-- <a href={`/cloud/${data.service.id}/graph/?id=${assessment.resourceId}`}>
+											{assessment.resourceId.split('/')[
+												assessment.resourceId.split('/').length - 1
+											]}
+										</a> -->
 									</span>
 								</td>
 								<td class="whitespace-nowrap px-6 py-4">
@@ -164,6 +161,17 @@ https://svelte.dev/e/node_invalid_placement -->
 									<Button on:click={() => showDetails(assessment.id)}>More Details</Button>
 								</td>
 							</tr>
+							{#if showModalId === assessment.id}
+							<tr>
+								<td colspan="6" class="bg-gray-50 px-6 py-4">
+								  <pre class="whitespace-pre-wrap text-xs font-mono">
+							{JSON.stringify(assessment, null, 2)}
+								  </pre>
+							
+								  <Button on:click={closeModal}>Close</Button>
+								</td>
+							  </tr>
+							{/if}
 						{/each}
 					</tbody>
 				</table>

--- a/src/routes/(app)/cloud/[id]/assessments/+page.ts
+++ b/src/routes/(app)/cloud/[id]/assessments/+page.ts
@@ -1,4 +1,4 @@
-import { listCertificationTargetAssessmentResults } from '$lib/api/orchestrator';
+import { listTargetOfEvaluationAssessmentResults } from '$lib/api/orchestrator';
 
 import { error } from '@sveltejs/kit';
 
@@ -12,7 +12,7 @@ export const load = (async ({ fetch, params, url }) => {
 	const filterIds = url.searchParams.get('filterIds')?.split(',') ?? [];
 	const filterResourceId = url.searchParams.get('filterResourceId');
 	const page = Number(url.searchParams.get('page'));
-	const results = await listCertificationTargetAssessmentResults(params.id, fetch);
+	const results = await listTargetOfEvaluationAssessmentResults(params.id, fetch);
 
 	return {
 		filterIds,

--- a/src/routes/(app)/cloud/[id]/compliance/+layout.ts
+++ b/src/routes/(app)/cloud/[id]/compliance/+layout.ts
@@ -27,7 +27,7 @@ export const load = (async ({ fetch, params, parent }) => {
 	// Retrieve the result of each "parent" (aka the top controls), because in the
 	// overview we are only interested in that
 	const topControlResults = await listEvaluationResults(
-		{ cloudServiceId: params.id, parentsOnly: true },
+		{ targetOfEvaluationId: params.id, parentsOnly: true },
 		true,
 		fetch
 	);
@@ -35,7 +35,7 @@ export const load = (async ({ fetch, params, parent }) => {
 	return {
 		targets,
 		/**
-		 * This array contains all catalogs which do not have a target of evaluation
+		 * This array contains all catalogs which do not have a Target of Evaluation
 		 * and are possible ready to be selected for evaluation.
 		 */
 		leftOverCatalogs,

--- a/src/routes/(app)/cloud/[id]/compliance/+page.svelte
+++ b/src/routes/(app)/cloud/[id]/compliance/+page.svelte
@@ -37,7 +37,7 @@
 	}
 
 	async function remove(e: CustomEvent<{ auditScope: AuditScope }>) {
-		let really = confirm('Do you really want to remove this target of evaluation?');
+		let really = confirm('Do you really want to remove this Target of Evaluation?');
 
 		if (!really) {
 			return;

--- a/src/routes/(app)/cloud/[id]/compliance/[catalogId]/+page.svelte
+++ b/src/routes/(app)/cloud/[id]/compliance/[catalogId]/+page.svelte
@@ -65,7 +65,7 @@
 		let result: EvaluationResult = {
 			id: '',
 			controlId: control.id,
-			cloudServiceId: data.service.id,
+			targetOfEvaluationId: data.service.id,
 			controlCategoryName: control.categoryName,
 			controlCatalogId: data.catalog.id,
 			parentControlId: control.parentControlId,

--- a/src/routes/(app)/cloud/[id]/compliance/[catalogId]/+page.ts
+++ b/src/routes/(app)/cloud/[id]/compliance/[catalogId]/+page.ts
@@ -13,7 +13,7 @@ export const load = (async ({ fetch, params, url }) => {
 	const catalog = await getCatalog(params.catalogId, fetch);
 	const evaluations = await listEvaluationResults(
 		{
-			cloudServiceId: params.id,
+			targetOfEvaluationId: params.id,
 			catalogId: params.catalogId
 		},
 		true,

--- a/src/routes/(app)/cloud/[id]/compliance/new/+page.svelte
+++ b/src/routes/(app)/cloud/[id]/compliance/new/+page.svelte
@@ -22,9 +22,10 @@
 	} satisfies WizardData);
 
 	async function save(event: CustomEvent<WizardData>) {
-		// Afterwards, create the targets of evaluation
+		// Afterwards, create the Targets of Evaluation
 		let auditScopes = await Promise.all(
 			event.detail.auditScopes.map((auditScope) => {
+				auditScope.name = "UI generated Audit Scope"
 				return createAuditScope(auditScope);
 			})
 		);

--- a/src/routes/(app)/cloud/[id]/graph/+page.svelte
+++ b/src/routes/(app)/cloud/[id]/graph/+page.svelte
@@ -7,8 +7,7 @@
 	import Button from '$lib/components/Button.svelte';
 	import { ViewfinderCircle } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
-	import { pushState, replaceState } from '$app/navigation';
-
+	
 	interface Props {
 		data: PageData;
 	}
@@ -39,6 +38,7 @@
 			}
 
 			return {
+				group: 'nodes',
 				data: {
 					id: n.id,
 					status: status,
@@ -55,6 +55,7 @@
 	let edges = $derived(
 		data.edges.map((e) => {
 			return {
+				group: 'edges',
 				data: e
 			} satisfies EdgeDefinition;
 		})
@@ -94,7 +95,7 @@
 <div class="overflow-hidden rounded-xl border border-gray-200">
 	<div class="flex items-center justify-between gap-x-4 border-b border-gray-900/5 bg-gray-50 p-4">
 		<div class="text-sm text-gray-500">
-			This graph provides an overview over all discovered resources of the Cloud service,
+			This graph provides an overview over all discovered resources of the Target of Evaluation,
 			infrastructure as well as application source-code.
 		</div>
 		<div class="flex gap-x-1.5">

--- a/src/routes/(app)/cloud/[id]/graph/+page.ts
+++ b/src/routes/(app)/cloud/[id]/graph/+page.ts
@@ -1,16 +1,16 @@
 import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
-import { listGraphEdges } from '$lib/api/discovery';
+import { listGraphEdges } from '$lib/api/evidence_store';
 import { listAssessmentResults } from '$lib/api/orchestrator';
 
 export const load = (async ({ fetch, params, url }) => {
 	if (params.id == undefined) {
 		error(405, 'Required parameter missing');
 	}
-
+	
 	const results = await listAssessmentResults(fetch, true);
 	const edges = await listGraphEdges(fetch);
-
+	
 	return {
 		results,
 		edges

--- a/src/routes/(app)/cloud/[id]/resources/+page.svelte
+++ b/src/routes/(app)/cloud/[id]/resources/+page.svelte
@@ -3,8 +3,7 @@
 
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
-	import type { Resource } from '$lib/api/discovery';
-	import DiscoveryGraph from '$lib/components/DiscoveryGraph.svelte';
+	import type { Resource } from '$lib/api/evidence_store';
 	import StarterHint from '$lib/components/StarterHint.svelte';
 	import {
 		Check,
@@ -18,7 +17,6 @@
 		XCircle
 	} from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
-	import type { EdgeDefinition, NodeDefinition } from 'cytoscape';
 	import type { PageData } from './$types';
 
 	interface Props {
@@ -130,7 +128,7 @@
 		const results = data.results.filter((result) => result.resourceId === resourceId);
 		return results.length;
 	}
-	let currentPage;
+	let currentPage: number = $state(1);
 	run(() => {
 		currentPage = data.page ? data.page : 1;
 	});
@@ -138,7 +136,7 @@
 
 	let query = $derived(searchString.toLowerCase());
 
-	let filteredData;
+	let filteredData: Resource[] = data.resources;
 	run(() => {
 		filteredData = data.resources.filter((resource) => {
 			return (
@@ -150,7 +148,7 @@
 	let totalPages = $derived(Math.ceil(filteredData.length / rowsPerPage));
 	let searchActivated = $state(false);
 
-	let currentData;
+	let currentData: Resource[] = $state([]);
 	run(() => {
 		currentData = paginate(filteredData, currentPage);
 	});
@@ -160,7 +158,7 @@
 	<StarterHint type="discovered resources" icon={Squares2x2}>
 		{#snippet component()}
 			<span>
-				Clouditor Discovery with with the certification target ID <pre>{data.service.id}</pre>
+				Clouditor Discovery with the Target of Evaluation ID <pre>{data.service.id}</pre>
 			</span>
 		{/snippet}
 	</StarterHint>

--- a/src/routes/(app)/cloud/[id]/resources/+page.ts
+++ b/src/routes/(app)/cloud/[id]/resources/+page.ts
@@ -1,22 +1,23 @@
-import { listCertificationTargetAssessmentResults } from '$lib/api/orchestrator';
+import { listTargetOfEvaluationAssessmentResults } from '$lib/api/orchestrator';
 
 import { error } from '@sveltejs/kit';
 
 import type { PageLoad } from './$types';
-import { listGraphEdges } from '$lib/api/discovery';
+import { listGraphEdges, listResources } from '$lib/api/evidence_store';
 
 export const load = (async ({ fetch, params, url }) => {
 	if (params.id == undefined) {
 		error(405, 'Required parameter missing');
 	}
 
-	const results = await listCertificationTargetAssessmentResults(params.id, fetch);
-	const edges = await listGraphEdges();
+	const results = await listTargetOfEvaluationAssessmentResults(params.id, fetch);
+	// const edges = await listGraphEdges();
+	const resource = await listResources(params.id, '', fetch);
 	const page = Number(url.searchParams.get('page'));
 
 	return {
 		results,
-		edges,
+		// edges,
 		page
 	};
 }) satisfies PageLoad;

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -3,9 +3,3 @@
 <p class="text-base">Very awesome stuff here</p>
 
 You can try a<a href="/cloud">list of evaluation targets</a>
-
-<style lang="postcss">
-	:global(html) {
-		background-color: theme(colors.gray.100);
-	}
-</style>

--- a/src/routes/(app)/metrics/[...metricId]/+page.svelte
+++ b/src/routes/(app)/metrics/[...metricId]/+page.svelte
@@ -42,7 +42,7 @@
 				<p class="ml-16 truncate text-sm font-medium text-gray-500">Target Value</p>
 			</dt>
 			<dd class="ml-16 flex items-baseline">
-				<p class="text-2xl font-semibold text-gray-900">{data.metricConfiguration.targetValue}</p>
+				<p class="text-2xl font-semibold text-gray-900">{JSON.stringify(data.metricConfiguration.targetValue)}</p>
 			</dd>
 		</div>
 		<div class="relative overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 shadow">

--- a/src/routes/(marketing)/about/+layout.svelte
+++ b/src/routes/(marketing)/about/+layout.svelte
@@ -26,7 +26,7 @@
 			name: 'Holistic.',
 			path: '/about/page3',
 			description:
-				'Using integrations with other tools, such as Codyze, we can provide a holistic view of the certification target, from infrastructure to code.',
+				'Using integrations with other tools, such as Codyze, we can provide a holistic view of the Target of Evaluation, from infrastructure to code.',
 			icon: PuzzlePiece
 		}
 	];


### PR DESCRIPTION
After a lot of changes in the Clouditor, we have to update the UI. 
- Renaming CertificationTarget -> TargetOfEvaluation
- Update evidenceStore endpoints
- Update discovery endpoints
- FIx StopEvaluation endpoint
- Fix createAuditScope()
- Extend ListGraphEdgesRequest()
- Change 'DiscoveredResources' view to only load resources and not graph data
- FIx `Morę Details` in AssessmentResults view
- Use stringify() for metrics targetValues